### PR TITLE
Changing layer5 link to meshery link

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -12,6 +12,6 @@ assignees: ''
 
 ---
 **Contributor Resources**
-- [Meshery documentation site](https://meshery.layer5.io/docs/)
-- [Meshery documentation source](https://github.com/layer5io/meshery/tree/master/docs)
-- [Instructions for contributing to documentation](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#documentation-contribution-flow)
+- [Meshery documentation site](https://docs.meshery.io/)
+- [Meshery documentation source](https://github.com/meshery/meshery/tree/master/docs)
+- [Instructions for contributing to documentation](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#documentation-contribution-flow)


### PR DESCRIPTION
Signed-off-by: sayantan1413 <sayantanbose2001@gmail.com>

Changed the layer5 link to meshery link