### PR TITLE
version changed to 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15 as builder
+FROM golang:1.23 as builder
 # Replace <adapter-name> to what you want to create
 # Replace <service-mesh> to the service-mesh application name
 ARG ENVIRONMENT="development"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/layer5io/meshery-adapter-template
 
-go 1.15
+go 1.23
 
 require (
 	github.com/golang/protobuf v1.4.3


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #60 

This PR updates the Go version from 1.15 to 1.23, ensuring compatibility with the latest features and improvements. It includes necessary updates to go.mod and Dockerfile and verifies that all dependencies are aligned.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
